### PR TITLE
Fix keyboard auto correction

### DIFF
--- a/res/layout/account_selection.xml
+++ b/res/layout/account_selection.xml
@@ -91,7 +91,7 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="5dip"
         android:hint="imap notes server"
-        android:inputType="text" >
+        android:inputType="textNoSuggestions|text|textVisiblePassword" >
     </EditText>
 
     <TextView

--- a/res/layout/new_note.xml
+++ b/res/layout/new_note.xml
@@ -13,7 +13,7 @@
             android:id="@+id/editNote"
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
-            android:inputType="textNoSuggestions|textMultiLine|textVisiblePassword"
+            android:inputType="textMultiLine"
             android:ems="10" >
 
             <requestFocus></requestFocus>

--- a/res/layout/note_detail.xml
+++ b/res/layout/note_detail.xml
@@ -9,7 +9,7 @@
     android:layout_width="fill_parent" android:layout_height="fill_parent">
       <EditText android:layout_width="fill_parent"
 		android:id="@+id/bodyView" 
-		android:inputType="textNoSuggestions|textMultiLine|textVisiblePassword"
+		android:inputType="textMultiLine"
 		android:layout_height="fill_parent" 
 		android:gravity="top"
 		android:onClick="onClick"


### PR DESCRIPTION
This PR fixes the following issues:
- server name in account settings is no longer auto-corrected
- new and existing notes now have auto-correction from the keyboard (fixes #8)
