### PR TITLE
typofix

### DIFF
--- a/ImapNote2/src/main/res/layout/account_selection.xml
+++ b/ImapNote2/src/main/res/layout/account_selection.xml
@@ -91,7 +91,7 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="5dip"
         android:hint="imap notes server"
-        android:inputType="extNoSuggestions|text|textVisiblePassword" >
+        android:inputType="textNoSuggestions|text|textVisiblePassword" >
     </EditText>
 
     <TextView


### PR DESCRIPTION
added the missing „t“ in one of the layout files
