### PR TITLE
Added feature to specify full path to the mailfolder 

### DIFF
--- a/ImapNote2/src/main/java/com/Pau/ImapNotes2/AccontConfigurationActivity.java
+++ b/ImapNote2/src/main/java/com/Pau/ImapNotes2/AccontConfigurationActivity.java
@@ -46,6 +46,7 @@ public class AccontConfigurationActivity extends AccountAuthenticatorActivity im
   private TextView serverTextView;
   private TextView portnumTextView;
   private TextView syncintervalTextView;
+  private TextView folderTextView;
   private CheckBox stickyCheckBox;
   private Spinner securitySpinner;
   private ImapNotes2Account imapNotes2Account;
@@ -107,6 +108,7 @@ public class AccontConfigurationActivity extends AccountAuthenticatorActivity im
     this.serverTextView = (TextView)findViewById(R.id.serverEdit);
     this.portnumTextView = (TextView)findViewById(R.id.portnumEdit);
     this.syncintervalTextView = (TextView)findViewById(R.id.syncintervalEdit);
+    this.folderTextView = (TextView)findViewById(R.id.folderEdit);
     this.stickyCheckBox = (CheckBox)findViewById(R.id.stickyCheckBox);
 
     securitySpinner = (Spinner) findViewById(R.id.securitySpinner);
@@ -150,6 +152,7 @@ public class AccontConfigurationActivity extends AccountAuthenticatorActivity im
         this.securitySpinner.setSelection(this.security_i);
         this.stickyCheckBox.setChecked(Boolean.parseBoolean(this.settings.GetUsesticky()));
         this.syncintervalTextView.setText("15");
+        this.folderTextView.setText(this.settings.GetFoldername());
     }
 
     LinearLayout layout = (LinearLayout) findViewById(R.id.bttonsLayout);
@@ -173,7 +176,8 @@ public class AccontConfigurationActivity extends AccountAuthenticatorActivity im
         this.portnumTextView.setText(this.accountManager.getUserData(myAccount, "portnum"));
         this.security = this.accountManager.getUserData (myAccount, "security");
         this.stickyCheckBox.setChecked(Boolean.parseBoolean(this.accountManager.getUserData(myAccount,"usesticky")));
-        syncintervalTextView.setText(this.accountManager.getUserData(myAccount, "syncinterval"));
+        this.syncintervalTextView.setText(this.accountManager.getUserData(myAccount, "syncinterval"));
+        this.folderTextView.setText(this.accountManager.getUserData (myAccount, "imapfolder"));
         if (this.security == null) this.security = "0";
         this.security_i = Integer.parseInt(this.security);
         this.securitySpinner.setSelection(this.security_i);
@@ -210,8 +214,9 @@ public class AccontConfigurationActivity extends AccountAuthenticatorActivity im
     this.imapNotes2Account.SetSecurity(this.security);
     this.imapNotes2Account.SetUsesticky(String.valueOf(this.stickyCheckBox.isChecked()));
     this.imapNotes2Account.SetSyncinterval(this.syncintervalTextView.getText().toString());
-    
-    new LoginThread().execute(this.imapFolder, this.imapNotes2Account, loadingDialog, this, this.action);
+    this.imapNotes2Account.SetFoldername(this.folderTextView.getText().toString());
+    long SYNC_FREQUENCY = Long.parseLong(syncintervalTextView.getText().toString(), 10) * 60;
+    new LoginThread().execute(this.imapFolder, this.imapNotes2Account, loadingDialog, this, this.action, SYNC_FREQUENCY);
     
   }
   
@@ -230,11 +235,12 @@ public class AccontConfigurationActivity extends AccountAuthenticatorActivity im
             ((ImapNotes2Account)stuffs[1]).GetServer(),
             ((ImapNotes2Account)stuffs[1]).GetPortnum(),
             ((ImapNotes2Account)stuffs[1]).GetSecurity(),
-            ((ImapNotes2Account)stuffs[1]).GetUsesticky());
+            ((ImapNotes2Account)stuffs[1]).GetUsesticky(),
+            ((ImapNotes2Account)stuffs[1]).GetFoldername());
           accontConfigurationActivity = (AccontConfigurationActivity)stuffs[3];
           if (this.res.returnCode==0) {
             Account account = new Account(((ImapNotes2Account)stuffs[1]).GetAccountname(), "com.Pau.ImapNotes2");
-            long SYNC_FREQUENCY = Long.parseLong(syncintervalTextView.getText().toString(), 10) * 60;
+            long SYNC_FREQUENCY = (long)stuffs[5];
             AccountManager am = AccountManager.get(((AccontConfigurationActivity)stuffs[3]));
             accontConfigurationActivity.setResult(AccontConfigurationActivity.TO_REFRESH);
             Bundle result = null;
@@ -249,6 +255,7 @@ public class AccontConfigurationActivity extends AccountAuthenticatorActivity im
                   am.setUserData(account, "syncinterval", ((ImapNotes2Account)stuffs[1]).GetSyncinterval());
                   am.setUserData(account, "security", ((ImapNotes2Account)stuffs[1]).GetSecurity());
                   am.setUserData(account, "usesticky", ((ImapNotes2Account)stuffs[1]).GetUsesticky());
+                  am.setUserData(account, "imapfolder", ((ImapNotes2Account)stuffs[1]).GetFoldername());
                   // Run the Sync Adapter Periodically
                   ContentResolver.setIsSyncable(account, AUTHORITY, 1);
                   ContentResolver.setSyncAutomatically(account, AUTHORITY, true);
@@ -267,6 +274,7 @@ public class AccontConfigurationActivity extends AccountAuthenticatorActivity im
                   am.setUserData(account, "syncinterval", ((ImapNotes2Account)stuffs[1]).GetSyncinterval());
                   am.setUserData(account, "security", ((ImapNotes2Account)stuffs[1]).GetSecurity());
                   am.setUserData(account, "usesticky", ((ImapNotes2Account)stuffs[1]).GetUsesticky());
+                  am.setUserData(account, "imapfolder", ((ImapNotes2Account)stuffs[1]).GetFoldername());
                   // Run the Sync Adapter Periodically
                   ContentResolver.setIsSyncable(account, AUTHORITY, 1);
                   ContentResolver.setSyncAutomatically(account, AUTHORITY, true);
@@ -297,6 +305,7 @@ public class AccontConfigurationActivity extends AccountAuthenticatorActivity im
           this.accontConfigurationActivity.portnumTextView.setText("");
           this.accontConfigurationActivity.syncintervalTextView.setText("15");
           this.accontConfigurationActivity.securitySpinner.setSelection(0);
+          this.accontConfigurationActivity.folderTextView.setText("");
           this.accontConfigurationActivity.stickyCheckBox.setChecked(false);
         }
     	final Toast tag = Toast.makeText(getApplicationContext(), this.res.errorMessage,Toast.LENGTH_LONG);

--- a/ImapNote2/src/main/java/com/Pau/ImapNotes2/Data/ConfigurationFile.java
+++ b/ImapNote2/src/main/java/com/Pau/ImapNotes2/Data/ConfigurationFile.java
@@ -26,6 +26,7 @@ public class ConfigurationFile {
     private String portnum;
     private String security;
     private String usesticky;
+    private String imapfolder;
     
     
     public ConfigurationFile(Context myContext){
@@ -37,6 +38,7 @@ public class ConfigurationFile {
             this.username = this.LoadItemFromXML(fileToLoad, "username").item(0).getChildNodes().item(0).getNodeValue();
             this.password = this.LoadItemFromXML(fileToLoad, "password").item(0).getChildNodes().item(0).getNodeValue();
             this.server = this.LoadItemFromXML(fileToLoad, "server").item(0).getChildNodes().item(0).getNodeValue();
+            this.imapfolder = this.LoadItemFromXML(fileToLoad, "imapfolder").item(0).getChildNodes().item(0).getNodeValue();
             this.accountname = this.username + "@" + this.server;
             if (this.LoadItemFromXML(fileToLoad, "portnum").getLength() == 0)
                 // portnum option doesn't exist
@@ -64,6 +66,7 @@ public class ConfigurationFile {
             this.portnum = "";
             this.security = "0";
             this.usesticky = "false";
+            this.imapfolder = "";
         }
     }
     
@@ -118,6 +121,10 @@ public class ConfigurationFile {
     public void SetUsesticky(String Usesticky){
         this.usesticky = Usesticky;
     }
+
+    public String GetFoldername(){
+        return this.imapfolder;
+    }
     
     public void Clear(){
         new File(this.applicationContext.getFilesDir()+"/ImapNotes2.conf").delete();
@@ -126,7 +133,8 @@ public class ConfigurationFile {
         this.server=null;
         this.portnum=null;
         this.security=null;
-        this.usesticky=null;   
+        this.usesticky=null;
+        this.imapfolder = null;
     }
     
     public void SaveConfigurationToXML() throws IllegalArgumentException, IllegalStateException, IOException{
@@ -150,6 +158,9 @@ public class ConfigurationFile {
         serializer.startTag(null, "security");
         serializer.text(this.security);
         serializer.endTag(null, "security");
+        serializer.startTag(null,"imapfolder");
+        serializer.text(this.imapfolder);
+        serializer.endTag(null, "imapfolder");
         serializer.startTag(null, "usesticky");
         serializer.text(this.usesticky);
         serializer.endTag(null, "usesticky");

--- a/ImapNote2/src/main/java/com/Pau/ImapNotes2/Data/ImapNotes2Account.java
+++ b/ImapNote2/src/main/java/com/Pau/ImapNotes2/Data/ImapNotes2Account.java
@@ -12,6 +12,7 @@ public class ImapNotes2Account {
     private String security = "";
     private String usesticky = "";
     private String syncinterval = "15";
+    private String imapfolder = "";
     private Boolean accountHasChanged = false;
     private Account account = null;
     
@@ -22,7 +23,7 @@ public class ImapNotes2Account {
     public String toString() {
         return this.accountname + ":" + this.username + ":" + this.password + ":"
 	    + this.server + ":" + this.portnum + ":" + this.security + ":"
-            + this.usesticky + ":" + this.accountHasChanged.toString();
+            + this.usesticky + ":" + this.imapfolder + ":" + this.accountHasChanged.toString();
         }
 
     public String GetAccountname() {
@@ -109,6 +110,14 @@ public class ImapNotes2Account {
     public Boolean GetaccountHasChanged() {
         return this.accountHasChanged;
     }
+
+    public String GetFoldername(){
+        return this.imapfolder;
+    }
+
+    public void SetFoldername(String folder) {
+        this.imapfolder = folder;
+    }
     
     public void Clear() {
         this.username=null;
@@ -117,6 +126,7 @@ public class ImapNotes2Account {
         this.portnum=null;
         this.security=null;
         this.usesticky=null;
+        this.imapfolder=null;
         this.accountHasChanged=false;
     }
 }

--- a/ImapNote2/src/main/java/com/Pau/ImapNotes2/Miscs/ImapNotes2Result.java
+++ b/ImapNote2/src/main/java/com/Pau/ImapNotes2/Miscs/ImapNotes2Result.java
@@ -15,6 +15,6 @@ public class ImapNotes2Result {
 		errorMessage = "";
 		UIDValidity = (long) -1;
 		hasUIDPLUS = true;
-                notesFolder = null;
+		notesFolder = null;
 	}
 }

--- a/ImapNote2/src/main/java/com/Pau/ImapNotes2/Miscs/Imaper.java
+++ b/ImapNote2/src/main/java/com/Pau/ImapNotes2/Miscs/Imaper.java
@@ -34,17 +34,23 @@ public class Imaper {
   private String proto;
   private String acceptcrt;
   private static String sfolder = "Notes";
+  private String folderoverride;
   private Folder notesFolder = null;
   private ImapNotes2Result res;
   private Long UIDValidity;
 private Boolean useProxy = false;
 public static final String PREFS_NAME = "PrefsFile";
   
-  public ImapNotes2Result ConnectToProvider(String username, String password, String server, String portnum, String security, String usesticky) throws MessagingException{
+  public ImapNotes2Result ConnectToProvider(String username, String password, String server, String portnum, String security, String usesticky, String override) throws MessagingException{
     if (this.IsConnected())
       this.store.close();
     
   res = new ImapNotes2Result();
+    if (override==null) {
+      this.folderoverride = "";
+    } else {
+      this.folderoverride = override;
+    }
   this.proto = "";
   this.acceptcrt = "";
   int security_i = Integer.parseInt(security);
@@ -134,11 +140,13 @@ Boolean hasUIDPLUS = ((IMAPStore) this.store).hasCapability("UIDPLUS");
       Folder[] folders = store.getPersonalNamespaces();
       Folder folder = folders[0];
 //Log.d(TAG,"Personal Namespaces="+folder.getFullName());
-      if (folder.getFullName().length() == 0) {
+      if (this.folderoverride.length() > 0) {
+          Imaper.sfolder = this.folderoverride;
+      } else if (folder.getFullName().length() == 0) {
           Imaper.sfolder = "Notes";
       } else {
-	      char separator = folder.getSeparator();
-	      Imaper.sfolder = folder.getFullName() + separator + "Notes";            	
+          char separator = folder.getSeparator();
+          Imaper.sfolder = folder.getFullName() + separator + "Notes";
       }
       this.res.errorMessage = "";
       this.res.returnCode = 0;

--- a/ImapNote2/src/main/java/com/Pau/ImapNotes2/Sync/SyncAdapter.java
+++ b/ImapNote2/src/main/java/com/Pau/ImapNotes2/Sync/SyncAdapter.java
@@ -173,7 +173,8 @@ else am.setUserData(account, "syncinterval", "15");
               am.getUserData(account, "server"),
               am.getUserData(account, "portnum"),
               am.getUserData(account, "security"),
-              am.getUserData(account, "usesticky"));
+              am.getUserData(account, "usesticky"),
+              am.getUserData(account, "imapfolder"));
         } catch (MessagingException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();

--- a/ImapNote2/src/main/java/com/Pau/ImapNotes2/Sync/SyncUtils.java
+++ b/ImapNote2/src/main/java/com/Pau/ImapNotes2/Sync/SyncUtils.java
@@ -50,6 +50,7 @@ public class SyncUtils {
   static String proto;
   static String acceptcrt;
   static String sfolder = "Notes";
+  static private String folderoverride;
   static Folder notesFolder = null;
   static ImapNotes2Result res;
   static Long UIDValidity;
@@ -58,11 +59,16 @@ public class SyncUtils {
   private final static int ROOT_AND_NEW = 3;
 private static Boolean useProxy = false;
   
-  public static ImapNotes2Result ConnectToRemote(String username, String password, String server, String portnum, String security, String usesticky) throws MessagingException{
+  public static ImapNotes2Result ConnectToRemote(String username, String password, String server, String portnum, String security, String usesticky, String override) throws MessagingException{
     if (IsConnected())
       store.close();
-    
+
   res = new ImapNotes2Result();
+  if (override==null) {
+    folderoverride = "";
+  } else {
+    folderoverride = override;
+  }
   proto = "";
   acceptcrt = "";
   int security_i = Integer.parseInt(security);
@@ -145,11 +151,13 @@ private static Boolean useProxy = false;
       Folder[] folders = store.getPersonalNamespaces();
       Folder folder = folders[0];
 //Log.d(TAG,"Personal Namespaces="+folder.getFullName());
-      if (folder.getFullName().length() == 0) {
+      if (folderoverride.length() > 0) {
+          sfolder = folderoverride;
+      } else if (folder.getFullName().length() == 0) {
           sfolder = "Notes";
       } else {
           char separator = folder.getSeparator();
-          sfolder = folder.getFullName() + separator + "Notes";                
+          sfolder = folder.getFullName() + separator + "Notes";
       }
       // Get UIDValidity
       notesFolder = store.getFolder(sfolder);

--- a/ImapNote2/src/main/res/layout/account_selection.xml
+++ b/ImapNote2/src/main/res/layout/account_selection.xml
@@ -149,6 +149,22 @@
 
     </EditText>
 
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Notes Folder (optional)"
+        android:id="@+id/folderText"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:textColor="#000000" />
+
+    <EditText
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="5dip"
+        android:id="@+id/folderEdit"
+        android:textColor="#000000"
+        android:hint="manually set full imap path to notes folder" />
+
     <CheckBox
         android:id="@+id/stickyCheckBox"
         android:layout_width="match_parent"


### PR DESCRIPTION
I had the following Problem:
- ImapNotes2 did not sync with my account
- the Notes mailfolder is in INBOX.Notes but the app did not work
- I cannot add any folder at root level of mailbox
- javamail does not return 'INBOX' from the response '\* NAMESPACE (("INBOX." ".")) NIL (("#shared." ".")("shared." "."))'

Solution:
- added the ability to explicitely specify the imap folder to sync with
   e.g. INBOX.Notes in my case

This worked for me and I take this as an valuable feature making this app working for some more people/mailservers.

I am absolutely no guru in android programming. So review carefully and correct me everywhere.

regards
Axel
